### PR TITLE
Wiki link removed (as wiki.chaos-darmstadt no longer exists)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,5 @@ nav_links:
         C-Radar: '/c-radar.html'
         WizardsOfDos: '/wizardsofdos.html'
     right:
-        Wiki: 'https://wiki.chaos-darmstadt.de/'
         Kontakt: '/kontakt.html'
         Unterstützen: '/unterstuetzen.html'


### PR DESCRIPTION
This is #16 rebased on master.